### PR TITLE
Security: Restore security headers in vercel.json for static assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- date: 2025-11-09T19:00:00Z
+  agent: claude
+  change: Restored security headers in vercel.json for static asset protection
+  why: Headers in next.config.mjs only apply to Next.js server responses, not static files served by Vercel's CDN (public/, _next/static/). Removing headers from vercel.json left static assets unprotected against XSS, clickjacking, and MIME-type attacks
+  scope: [vercel.json]
+  verification: Security headers now applied to all responses including static assets (favicon.svg, robots.txt, JS bundles)
+  followups: Headers are now defined in both vercel.json (for static assets) and next.config.mjs (for server responses) - this is intentional and necessary
+
 - date: 2025-10-20T11:00:00Z
   agent: copilot
   change: Improved component implementations - list verification UI, task choice accessibility, session loading states, and form input handling

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,32 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "npm run build",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
CRITICAL FIX: Restore security headers to vercel.json to protect static assets.

ISSUE:
Previous commit removed headers from vercel.json, leaving static assets (favicon.svg, robots.txt, /_next/static/* bundles) without security protection.

EXPLANATION:
- next.config.mjs headers = Only apply to Next.js server responses
- vercel.json headers = Apply to ALL responses including static CDN files
- Both are needed for complete protection

SECURITY IMPACT:
Without vercel.json headers, static files are vulnerable to:
- XSS attacks (missing X-XSS-Protection)
- Clickjacking (missing X-Frame-Options)
- MIME-type attacks (missing X-Content-Type-Options)
- Privacy leaks (missing Referrer-Policy)

CHANGES:
- Restored security headers to vercel.json
- Kept headers in next.config.mjs (not redundant, serves different purpose)
- Updated CHANGELOG.md per repository guidelines

Credit: GitHub PR reviewers (chatgpt-codex-connector, Copilot AI)

Verification: All static assets now protected with security headers

## Summary by Sourcery

Restore security headers in vercel.json to protect static assets on the Vercel CDN, retain next.config.mjs headers for server responses, and update the changelog accordingly.

Bug Fixes:
- Restore security headers in vercel.json for static assets to guard against XSS, clickjacking, MIME-type attacks, and privacy leaks

Enhancements:
- Retain next.config.mjs headers for Next.js server responses distinct from vercel.json

Deployment:
- Reinstate security headers in vercel.json to apply to static assets served by Vercel CDN

Documentation:
- Update CHANGELOG.md entry to document the security header restoration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored critical security headers to protect static assets from common web vulnerabilities and strengthen overall application security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->